### PR TITLE
LibOQS integration

### DIFF
--- a/integration/liboqs/META.yml
+++ b/integration/liboqs/META.yml
@@ -1,0 +1,95 @@
+algDetails:
+  algVersion: FIPS205
+  eufCMA: 'true'
+  sufCMA: 'false'
+
+sources:
+  integration/liboqs/META.yml
+  plat_local.h
+  sha2_256.c
+  sha2_512.c
+  sha2_api.h
+  sha3_api.c
+  sha3_api.h
+  sha3_f1600.c
+  slh_adrs.h
+  slh_dsa.c
+  slh_dsa.h
+  slh_param.h
+  slh_prehash.c
+  slh_prehash.h
+  slh_sha2.c
+  slh_shake.c
+  slh_var.h
+  slh_sys.h
+  cbmc.h
+
+paramSets:
+  -
+    name: 128s
+    pkSize: 32
+    skSize: 64
+    sigSize: 7856
+    claimedNISTLevel: 1
+  -
+    name: 128f
+    pkSize: 32
+    skSize: 64
+    sigSize: 17088
+    claimedNISTLevel: 1
+  -  
+    name: 192s
+    pkSize: 48
+    skSize: 96
+    sigSize: 16224
+    claimedNISTLevel: 3
+  -  
+    name: 192f
+    pkSize: 48
+    skSize: 96
+    sigSize: 35664
+    claimedNISTLevel: 3
+  -  
+    name: 256s
+    pkSize: 64
+    skSize: 128
+    sigSize: 29792
+    claimedNISTLevel: 5
+  -  
+    name: 256f
+    pkSize: 64
+    skSize: 128
+    sigSize: 49856
+    claimedNISTLevel: 5
+
+hashAlgs:
+  -
+    name: sha2
+  -
+    name: shake
+
+prehashHashAlgs:
+  -
+    name: sha2_224
+  -
+    name: sha2_256
+  -
+    name: sha2_384
+  -
+    name: sha2_512
+  -
+    name: sha2_512/224
+  -
+    name: sha2_512/256
+  -
+    name: sha3_224
+  -
+    name: sha3_256
+  -
+    name: sha3_384
+  -
+    name: sha3_512
+  -
+    name: shake_128
+  -
+    name: shake_256

--- a/slh_dsa.c
+++ b/slh_dsa.c
@@ -10,8 +10,6 @@
 #include "slh_var.h"
 #include "slh_sys.h"
 
-#include "test/my_dbg.h"
-
 /* === Internal */
 
 /* helper functions to compute "len = len1 + len2" */

--- a/slh_prehash.c
+++ b/slh_prehash.c
@@ -47,7 +47,7 @@ static size_t hash_slh_dsa_pad(uint8_t *mp, const uint8_t *m, size_t m_sz,
   const uint8_t shake_256_oid[11] = {0x06, 0x09, 0x60, 0x86, 0x48, 0x01,
                                      0x65, 0x03, 0x04, 0x02, 0x0C};
 
-  if (ctx_sz > 256)
+  if (ctx_sz > 255)
   {
     return 0;
   }


### PR DESCRIPTION
I have added an integration directory which contain all additional files required for use of slh_dsa_c in the libOQS repository.

Additionally I have changed the maximum context size for prehash signing to 255 from 256 to get signature tests to pass in libOQS.